### PR TITLE
fix(hook): join config zone patterns onto ZoneMinder zone geometry by name

### DIFF
--- a/docs/guides/config.rst
+++ b/docs/guides/config.rst
@@ -439,7 +439,8 @@ The file is organized into these sections:
     (see :doc:`hooks` for full details)
 
 - ``monitors`` — per-monitor overrides for ``wait``, ``ml_sequence``,
-  ``stream_sequence``, and ``zones`` (with ``detection_pattern`` and ``ignore_pattern``)
+  ``stream_sequence``, and ``zones`` (``coords`` plus ``detection_pattern`` and
+  ``ignore_pattern``; ``coords`` may be omitted when ``import_zm_zones`` is on)
 
 .. _push_config:
 
@@ -555,7 +556,7 @@ Consumed by ``zm_detect.py`` / ``utils.py``:
      - Line thickness for polygon overlays (pixels)
    * - ``import_zm_zones``
      - ``no``
-     - Import zone definitions from ZoneMinder instead of using config zones
+     - Take zone polygons from ZoneMinder. Imported zones are matched to ``monitors.<id>.zones`` by name, so a config zone can supply ``detection_pattern``/``ignore_pattern`` without ``coords``. See :ref:`zone_geometry_from_zm`
    * - ``only_triggered_zm_zones``
      - ``no``
      - When ``yes``, import only ZM zones that triggered the alarm (forces ``import_zm_zones: yes``)
@@ -756,7 +757,8 @@ on model-specific keys (``object_weights``, ``face_detection_framework``,
 
 Any key from the sections above can be overridden per monitor. Dict values
 (``ml_sequence``, ``stream_sequence``) are deep-merged; scalar values are replaced.
-See :doc:`hooks` for zone configuration (``detection_pattern``, ``ignore_pattern``).
+See :doc:`hooks` for zone configuration (``detection_pattern``, ``ignore_pattern``, and
+taking zone geometry from ZoneMinder).
 
 Configuration Tools
 ---------------------

--- a/docs/guides/hooks.rst
+++ b/docs/guides/hooks.rst
@@ -313,7 +313,7 @@ under the ``monitors`` section. You can override the entire structure or just pa
 
 Per-monitor zones
 ^^^^^^^^^^^^^^^^^^
-You can define detection zones per monitor. Each zone specifies a polygon region and optionally
+You can define detection zones per monitor. Each zone names a polygon region and optionally
 a ``detection_pattern`` (regex of labels to look for in that zone) and an ``ignore_pattern``
 (regex of labels to suppress even if they match ``detection_pattern``).
 
@@ -329,18 +329,58 @@ a ``detection_pattern`` (regex of labels to look for in that zone) and an ``igno
          front_porch:
            coords: "0,0 200,300 700,900"
 
-- ``coords`` — polygon coordinates as ``"x1,y1 x2,y2 x3,y3 ..."``
+- ``coords`` — polygon coordinates as ``"x1,y1 x2,y2 x3,y3 ..."``. Optional; see
+  :ref:`zone_geometry_from_zm` below
 - ``detection_pattern`` — regex for which labels to accept in this zone (optional; if omitted, all labels match)
 - ``ignore_pattern`` — regex for labels to suppress in this zone even if ``detection_pattern`` allows them
   (optional). Useful for excluding parked cars or other stationary objects from a specific area.
 
-You can also import zones from ZoneMinder instead of defining them manually:
+.. _zone_geometry_from_zm:
+
+Letting ZoneMinder own the geometry
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Zone polygons are already drawn in the ZoneMinder web UI. Rather than copying them into
+``objectconfig.yml`` — where they go stale the moment a zone is edited in ZM — turn on
+``import_zm_zones`` and leave ``coords`` out:
 
 ::
 
    general:
      import_zm_zones: "yes"
      only_triggered_zm_zones: "no"
+
+   monitors:
+     999:
+       zones:
+         my_driveway:
+           detection_pattern: "(person|car)"
+           ignore_pattern: "(car|truck)"
+
+Each zone imported from ZoneMinder is matched against ``monitors.<id>.zones`` **by name**, and
+the config's patterns are applied to it. Names are compared with spaces turned into underscores
+and lowercased, so a ZM zone called ``My Driveway`` matches a config key of ``my_driveway``.
+ZoneMinder stays the source of truth for where the zone is; the config says which labels matter
+there.
+
+Precedence:
+
+- a config zone **with** ``coords`` pins its own geometry — the same-named ZM zone is not
+  imported on top of it
+- a config zone **without** ``coords`` takes its geometry from the ZM zone of the same name
+- a ZM zone with no matching config entry is imported with no pattern, so every label matches
+- if a config zone declares a pattern but has no ``coords`` and no ZM zone of that name is
+  imported, that is logged as an error — the zone would otherwise do nothing
+
+With ``only_triggered_zm_zones: "yes"``, only the ZM zones named in the alarm cause are imported
+(and ``import_zm_zones`` is forced to ``yes``). Config zones that were not triggered are simply
+absent, and no error is logged for them.
+
+.. note::
+
+   A monitor with no zones at all — no ``zones:`` block and ``import_zm_zones: "no"`` — is not
+   spatially filtered: a detection anywhere in the frame is kept. ``zm_detect`` logs this at Info
+   level on every run. If you want ZoneMinder's zones to gate detection, turn on
+   ``import_zm_zones``.
 
 
 

--- a/docs/guides/testing.rst
+++ b/docs/guides/testing.rst
@@ -175,7 +175,8 @@ Python unit / integration reference
      - ``-O`` dot-notation overrides: coercion, ``[index]`` / ``[name]`` paths,
        error/edge cases
    * - ``tests/test_config_flow.py``
-     - Monitor/remote config loading, deep-merge, ``import_zm_zones`` passthrough
+     - Monitor/remote config loading, deep-merge, ``import_zm_zones`` passthrough,
+       coords-less zones recorded for the ZM name join
    * - ``tests/test_utils_config.py``
      - ``process_config`` config resolution and zone parsing
    * - ``tests/test_output_format.py``
@@ -185,7 +186,8 @@ Python unit / integration reference
    * - ``tests/test_config_errors.py``
      - ``process_config`` error/exit paths
    * - ``tests/test_import_zm_zones.py``
-     - Zone import filtering (active/triggered)
+     - Zone import filtering (active/triggered), and the name-based join of config
+       patterns onto ZM zone geometry
    * - ``tests/test_zm_detect.py``
      - CLI argparse early-exits (version, missing config)
 

--- a/hook/objectconfig.example.yml
+++ b/hook/objectconfig.example.yml
@@ -54,7 +54,9 @@ general:
   poly_color: "(255,255,255)"
   poly_thickness: 2
 
-  # ZoneMinder zone import
+  # ZoneMinder zone import. When yes, zone polygons come from ZoneMinder and are
+  # matched to monitors.<id>.zones by name, so a config zone can supply
+  # detection_pattern/ignore_pattern without repeating coords.
   #import_zm_zones: "yes"
   only_triggered_zm_zones: "no"
 
@@ -269,3 +271,9 @@ monitors:
         ignore_pattern: "(car|truck)"
       some_other_area:
         coords: "0,0 200,300 700,900"
+      # coords are optional. With import_zm_zones: "yes", a zone with no coords
+      # is matched to the ZoneMinder zone of the same name (spaces -> underscores,
+      # lowercased) and these patterns are applied to ZM's polygon. That keeps
+      # ZoneMinder as the source of truth for the geometry.
+      #front_porch:
+      #  detection_pattern: "(person)"

--- a/hook/tests/conftest.py
+++ b/hook/tests/conftest.py
@@ -117,10 +117,15 @@ if os.path.abspath(_hook_dir) not in sys.path:
 # Stub logger that satisfies g.logger.Debug / Info / Error / Fatal
 # ---------------------------------------------------------------------------
 class StubLogger:
-    def Debug(self, level, msg): pass
-    def Info(self, msg): pass
-    def Warning(self, msg): pass
-    def Error(self, msg): pass
+    """Records what was logged so tests can assert on warnings/errors."""
+
+    def __init__(self):
+        self.debug, self.info, self.warning, self.error = [], [], [], []
+
+    def Debug(self, level, msg): self.debug.append(msg)
+    def Info(self, msg): self.info.append(msg)
+    def Warning(self, msg): self.warning.append(msg)
+    def Error(self, msg): self.error.append(msg)
     def Fatal(self, msg): raise SystemExit(msg)
     def close(self): pass
 
@@ -131,6 +136,7 @@ def reset_common_params():
     import zmes_hook_helpers.common_params as g
     g.config = {}
     g.polygons = []
+    g.zone_patterns = {}
     g.ctx = None
     g.logger = StubLogger()
     yield

--- a/hook/tests/test_config_flow.py
+++ b/hook/tests/test_config_flow.py
@@ -110,6 +110,98 @@ class TestMonitorOverrides:
         process_config({"config": patched_config, "monitorid": "1"}, ctx)
         assert g.config["poly_thickness"] == 4
 
+    def test_zone_without_coords_records_pattern_for_join(self, tmp_path, ctx):
+        """A zone with patterns but no coords is kept for the ZM join, not dropped. Ref: #48"""
+        cfg = {
+            "general": _minimal_general(import_zm_zones="yes"),
+            "ml": {
+                "ml_sequence": {"general": {"model_sequence": "object"}},
+                "stream_sequence": {"resize": 800},
+            },
+            "monitors": {
+                5: {
+                    "zones": {
+                        "Front Yard": {
+                            "detection_pattern": "(person|car)",
+                            "ignore_pattern": "(cat)",
+                        },
+                    },
+                },
+            },
+        }
+        cfg_path = _make_config_file(tmp_path, cfg)
+        process_config({"config": cfg_path, "monitorid": "5"}, ctx)
+
+        assert g.polygons == []
+        assert g.zone_patterns == {
+            "front_yard": {"pattern": "(person|car)", "ignore_pattern": "(cat)"},
+        }
+        assert g.logger.error == []
+
+    def test_zone_without_coords_errors_when_import_off(self, tmp_path, ctx):
+        """Without import_zm_zones there is no geometry to join to, so say so. Ref: #48"""
+        cfg = {
+            "general": _minimal_general(import_zm_zones="no"),
+            "ml": {
+                "ml_sequence": {"general": {"model_sequence": "object"}},
+                "stream_sequence": {"resize": 800},
+            },
+            "monitors": {
+                5: {"zones": {"front_yard": {"detection_pattern": "(person)"}}},
+            },
+        }
+        cfg_path = _make_config_file(tmp_path, cfg)
+        process_config({"config": cfg_path, "monitorid": "5"}, ctx)
+
+        assert g.polygons == []
+        assert any("front_yard" in m for m in g.logger.error)
+
+    def test_per_monitor_import_zm_zones_applies_before_zones(self, tmp_path, ctx):
+        """A per-monitor import_zm_zones override is in effect while zones are read. Ref: #48"""
+        cfg = {
+            "general": _minimal_general(import_zm_zones="no"),
+            "ml": {
+                "ml_sequence": {"general": {"model_sequence": "object"}},
+                "stream_sequence": {"resize": 800},
+            },
+            "monitors": {
+                5: {
+                    "import_zm_zones": "yes",
+                    "zones": {"front_yard": {"detection_pattern": "(person)"}},
+                },
+            },
+        }
+        cfg_path = _make_config_file(tmp_path, cfg)
+        process_config({"config": cfg_path, "monitorid": "5"}, ctx)
+
+        assert g.config["import_zm_zones"] == "yes"
+        assert g.zone_patterns["front_yard"]["pattern"] == "(person)"
+        assert g.logger.error == []
+
+    def test_zone_names_are_normalized(self, tmp_path, ctx):
+        """Config zone names are normalized so they can join ZM names. Ref: #48"""
+        cfg = {
+            "general": _minimal_general(),
+            "ml": {
+                "ml_sequence": {"general": {"model_sequence": "object"}},
+                "stream_sequence": {"resize": 800},
+            },
+            "monitors": {
+                5: {
+                    "zones": {
+                        "Front Yard": {
+                            "coords": "0,0 10,0 10,10",
+                            "detection_pattern": "(person)",
+                        },
+                    },
+                },
+            },
+        }
+        cfg_path = _make_config_file(tmp_path, cfg)
+        process_config({"config": cfg_path, "monitorid": "5"}, ctx)
+
+        assert [p["name"] for p in g.polygons] == ["front_yard"]
+
     def test_only_triggered_zm_zones_skips_polygons(self, tmp_path, ctx):
         """only_triggered_zm_zones=yes (global) skips zone polygons and sets import_zm_zones."""
         cfg = {

--- a/hook/tests/test_import_zm_zones.py
+++ b/hook/tests/test_import_zm_zones.py
@@ -11,9 +11,12 @@ from pyzm.models.zm import Zone
 
 
 class _FakeLogger:
+    def __init__(self):
+        self.error = []
+
     def Debug(self, *a, **kw): pass
     def Info(self, *a, **kw): pass
-    def Error(self, *a, **kw): pass
+    def Error(self, msg): self.error.append(msg)
 
 
 def _make_zone(name, coords, zone_type="Active"):
@@ -29,6 +32,7 @@ def _make_zone(name, coords, zone_type="Active"):
 class TestImportZmZones:
     def setup_method(self):
         g.polygons = []
+        g.zone_patterns = {}
         g.logger = _FakeLogger()
         g.config = {
             'only_triggered_zm_zones': 'no',
@@ -161,3 +165,115 @@ class TestImportZmZones:
 
         import_zm_zones("1", None, mock_zm)
         assert g.polygons[0]['name'] == 'front_yard_camera_1'
+
+
+class TestConfigPatternJoin:
+    """Config patterns join onto ZM geometry by zone name. Ref: #48"""
+
+    def setup_method(self):
+        g.polygons = []
+        g.zone_patterns = {}
+        g.logger = _FakeLogger()
+        g.config = {
+            'only_triggered_zm_zones': 'no',
+            'import_zm_zones': 'yes',
+        }
+
+    def _client(self, zones):
+        mock_zm = MagicMock()
+        mock_monitor = MagicMock()
+        mock_monitor.get_zones.return_value = zones
+        mock_zm.monitor.return_value = mock_monitor
+        return mock_zm
+
+    def test_config_pattern_applied_to_imported_zone(self):
+        """A config zone with patterns but no coords stamps them onto ZM's geometry."""
+        from zmes_hook_helpers.utils import import_zm_zones
+
+        g.zone_patterns = {
+            'front_yard': {'pattern': '(person|car)', 'ignore_pattern': '(cat)'},
+        }
+        import_zm_zones("1", None, self._client([
+            _make_zone("Front Yard", "0,0 100,0 100,100 0,100"),
+        ]))
+
+        assert len(g.polygons) == 1
+        poly = g.polygons[0]
+        assert poly['name'] == 'front_yard'
+        assert poly['value'] == [(0.0, 0.0), (100.0, 0.0), (100.0, 100.0), (0.0, 100.0)]
+        assert poly['pattern'] == '(person|car)'
+        assert poly['ignore_pattern'] == '(cat)'
+        assert g.logger.error == []
+
+    def test_zone_without_config_entry_keeps_none_pattern(self):
+        """A ZM zone the config says nothing about is imported unchanged."""
+        from zmes_hook_helpers.utils import import_zm_zones
+
+        g.zone_patterns = {'front_yard': {'pattern': '(person)', 'ignore_pattern': None}}
+        import_zm_zones("1", None, self._client([
+            _make_zone("Front Yard", "0,0 100,0 100,100 0,100"),
+            _make_zone("Back Yard", "0,0 50,0 50,50 0,50"),
+        ]))
+
+        back = [p for p in g.polygons if p['name'] == 'back_yard'][0]
+        assert back['pattern'] is None
+        assert back['ignore_pattern'] is None
+
+    def test_config_coords_win_and_zm_zone_not_duplicated(self):
+        """A config zone with coords pins geometry; the same ZM zone is not appended."""
+        from zmes_hook_helpers.utils import import_zm_zones
+
+        g.polygons = [{
+            'name': 'front_yard',
+            'value': [(1.0, 1.0), (2.0, 1.0), (2.0, 2.0)],
+            'pattern': '(person)',
+            'ignore_pattern': None,
+        }]
+        g.zone_patterns = {'front_yard': {'pattern': '(person)', 'ignore_pattern': None}}
+        import_zm_zones("1", None, self._client([
+            _make_zone("Front Yard", "0,0 100,0 100,100 0,100"),
+        ]))
+
+        assert len(g.polygons) == 1
+        assert g.polygons[0]['value'] == [(1.0, 1.0), (2.0, 1.0), (2.0, 2.0)]
+        assert g.logger.error == []
+
+    def test_unmatched_config_pattern_logs_error(self):
+        """A pattern-only zone matching no imported ZM zone is reported, not silent."""
+        from zmes_hook_helpers.utils import import_zm_zones
+
+        g.zone_patterns = {'no_such_zone': {'pattern': '(person)', 'ignore_pattern': None}}
+        import_zm_zones("1", None, self._client([
+            _make_zone("Front Yard", "0,0 100,0 100,100 0,100"),
+        ]))
+
+        assert len(g.polygons) == 1
+        assert any('no_such_zone' in m for m in g.logger.error)
+
+    def test_unmatched_config_pattern_silent_when_only_triggered(self):
+        """Under only_triggered_zm_zones a non-triggered zone is legitimately absent."""
+        from zmes_hook_helpers.utils import import_zm_zones
+
+        g.config['only_triggered_zm_zones'] = 'yes'
+        g.zone_patterns = {'backyard': {'pattern': '(person)', 'ignore_pattern': None}}
+        import_zm_zones("1", "Motion: Driveway", self._client([
+            _make_zone("Driveway", "0,0 100,0 100,100 0,100"),
+            _make_zone("Backyard", "0,0 50,0 50,50 0,50"),
+        ]))
+
+        assert [p['name'] for p in g.polygons] == ['driveway']
+        assert g.logger.error == []
+
+    def test_config_pattern_beats_zm_pattern(self):
+        """When ZM ever supplies a pattern, the config's still wins."""
+        from zmes_hook_helpers.utils import import_zm_zones
+
+        z = _make_zone("Front Yard", "0,0 100,0 100,100 0,100")
+        z.pattern = "(dog)"
+        z.ignore_pattern = "(bird)"
+        g.zone_patterns = {'front_yard': {'pattern': '(person)', 'ignore_pattern': '(cat)'}}
+        import_zm_zones("1", None, self._client([z]))
+
+        assert g.polygons[0]['pattern'] == '(person)'
+        assert g.polygons[0]['ignore_pattern'] == '(cat)'
+

--- a/hook/zm_detect.py
+++ b/hook/zm_detect.py
@@ -80,7 +80,7 @@ def main_handler():
     g.logger.Debug(1, 'Log file: {}'.format(get_log_file() or '(file logging disabled)'))
     g.logger.Debug(1, '---------| app:{}, pyzm:{}, OpenCV:{}|------------'.format(__app_version__, pyzm_version, cv2.__version__))
 
-    g.polygons, g.ctx = [], ssl.create_default_context()
+    g.polygons, g.zone_patterns, g.ctx = [], {}, ssl.create_default_context()
     utils.process_config(args, g.ctx)
     os.makedirs(g.config['base_data_path'] + '/misc/', exist_ok=True)
 
@@ -107,6 +107,9 @@ def main_handler():
     # --- Detection ---
     stream_cfg = StreamConfig.from_dict(stream_options)
     zones = [Zone(name=p['name'], points=p['value'], pattern=p.get('pattern'), ignore_pattern=p.get('ignore_pattern')) for p in g.polygons]
+    if not zones:
+        g.logger.Info('No zones in effect: detections anywhere in the frame are kept. '
+                      'Set import_zm_zones: "yes" or define monitors.<id>.zones to gate by area.')
     matched_data = None
 
     # Inject remote gateway settings into ml_options so Detector.from_dict() picks them up

--- a/hook/zmes_hook_helpers/common_params.py
+++ b/hook/zmes_hook_helpers/common_params.py
@@ -5,6 +5,10 @@ ctx = None  # SSL context
 logger = None  # logging handler
 config = {}  # object that will hold config values
 polygons = []  # will contain mask(s) for a monitor
+# per-zone patterns from the config, keyed by normalized zone name. Zones
+# declared without coords live only here, until import_zm_zones() joins them
+# onto the geometry ZoneMinder owns.
+zone_patterns = {}
 
 # valid config keys and defaults
 config_vals = {

--- a/hook/zmes_hook_helpers/utils.py
+++ b/hook/zmes_hook_helpers/utils.py
@@ -105,7 +105,17 @@ def findWholeWord(w):
     return re.compile(r'\b({0})\b'.format(w), flags=re.IGNORECASE).search
 
 
-# Imports zone definitions from ZM via pyzm client
+def normalize_zone_name(name):
+    """Normalize a zone name so config zones and ZM zones join on it.
+
+    ZoneMinder allows spaces and mixed case in zone names; config keys are
+    written by hand. Both sides go through here before being compared.
+    """
+    return str(name).strip().replace(' ', '_').lower()
+
+
+# Imports zone definitions from ZM via pyzm client, joining any patterns the
+# config declared for a zone of the same name onto ZM's geometry.
 def import_zm_zones(mid, reason, zm_client):
 
     match_reason = False
@@ -115,6 +125,10 @@ def import_zm_zones(mid, reason, zm_client):
 
     monitor = zm_client.monitor(int(mid))
     zones = monitor.get_zones()
+
+    # zones the config already pinned geometry for -- those win over ZM's
+    config_coords = set(p['name'] for p in g.polygons)
+    joined = set()
 
     for z in zones:
         raw = z.raw().get('Zone', {})
@@ -128,15 +142,37 @@ def import_zm_zones(mid, reason, zm_client):
                 g.logger.Debug(1,'dropping {} as zones in alarm cause is {}'.format(z.name, reason))
                 continue
 
-        name = z.name.replace(' ','_').lower()
-        g.logger.Debug(2,'importing zoneminder polygon: {} [{}]'.format(name, z.points))
+        name = normalize_zone_name(z.name)
+        zone_cfg = g.zone_patterns.get(name)
+        if zone_cfg is not None:
+            joined.add(name)
+
+        if name in config_coords:
+            g.logger.Debug(1, 'not importing zoneminder zone {} as the config pins its coords'.format(name))
+            continue
+
+        zone_cfg = zone_cfg or {}
+        pattern = zone_cfg.get('pattern') or z.pattern
+        ignore_pattern = zone_cfg.get('ignore_pattern') or z.ignore_pattern
+        g.logger.Debug(2,'importing zoneminder polygon: {} [{}] pattern={} ignore_pattern={}'.format(
+            name, z.points, pattern, ignore_pattern))
         g.polygons.append({
             'name': name,
             'value': z.points,
-            'pattern': z.pattern,
-            'ignore_pattern': z.ignore_pattern,
+            'pattern': pattern,
+            'ignore_pattern': ignore_pattern,
         })
 
+    # A pattern-only zone that matched nothing silently does nothing. Say so.
+    # Under only_triggered_zm_zones a non-triggered zone is legitimately absent.
+    if g.config['only_triggered_zm_zones'] != 'yes':
+        for name, zone_cfg in g.zone_patterns.items():
+            if name in joined or name in config_coords:
+                continue
+            if zone_cfg.get('pattern') or zone_cfg.get('ignore_pattern'):
+                g.logger.Error(
+                    'zone "{}" declares a pattern but has no coords and no active ZoneMinder '
+                    'zone of that name was imported, so it has no effect'.format(name))
 
 
 def get_pyzm_config(args):
@@ -389,6 +425,7 @@ def process_config(args, ctx):
             g.logger.Debug(1, 'strict SSL cert checking is on...')
 
         g.polygons = []
+        g.zone_patterns = {}
 
         # Check if we have custom overrides for this monitor
         g.logger.Debug(2, 'Now checking for monitor overrides')
@@ -404,27 +441,9 @@ def process_config(args, ctx):
                 monitor_cfg = monitors.get(str(mid))
 
             if monitor_cfg:
-                # Process zone definitions
-                zones = monitor_cfg.get('zones', {})
-                for zone_name, zone_data in zones.items():
-                    coords_str = zone_data.get('coords', '')
-                    if coords_str:
-                        if g.config['only_triggered_zm_zones'] != 'yes':
-                            p = str2tuple(coords_str)
-                            pattern = zone_data.get('detection_pattern', None)
-                            ignore_pattern = zone_data.get('ignore_pattern', None)
-                            g.polygons.append({
-                                'name': zone_name,
-                                'value': p,
-                                'pattern': pattern,
-                                'ignore_pattern': ignore_pattern,
-                            })
-                            g.logger.Debug(2, 'adding polygon: {} [{}] pattern={} ignore_pattern={}'.format(
-                                zone_name, coords_str, pattern, ignore_pattern))
-                        else:
-                            g.logger.Debug(2, 'ignoring polygon: {} as only_triggered_zm_zones is true'.format(zone_name))
-
-                # Apply config overrides from monitor section (deep-merge dicts)
+                # Apply config overrides from monitor section (deep-merge dicts).
+                # This runs before the zone loop below so a per-monitor
+                # import_zm_zones/only_triggered_zm_zones is already in effect there.
                 for k, v in monitor_cfg.items():
                     if k in ('zones',):
                         continue
@@ -443,6 +462,40 @@ def process_config(args, ctx):
             # after ZMClient creation, via import_zm_zones(mid, reason, zm_client).
             if g.config['only_triggered_zm_zones'] == 'yes':
                 g.config['import_zm_zones'] = 'yes'
+
+            if monitor_cfg:
+                # Process zone definitions. coords are optional: a zone may name
+                # patterns only and let import_zm_zones() supply ZM's geometry.
+                zones = monitor_cfg.get('zones', {})
+                for zone_name, zone_data in zones.items():
+                    name = normalize_zone_name(zone_name)
+                    pattern = zone_data.get('detection_pattern', None)
+                    ignore_pattern = zone_data.get('ignore_pattern', None)
+                    g.zone_patterns[name] = {
+                        'pattern': pattern,
+                        'ignore_pattern': ignore_pattern,
+                    }
+                    coords_str = zone_data.get('coords', '')
+                    if not coords_str:
+                        if g.config['import_zm_zones'] == 'yes':
+                            g.logger.Debug(2, 'zone {} has no coords, taking geometry from ZoneMinder'.format(name))
+                        else:
+                            g.logger.Error(
+                                'zone "{}" has no coords and import_zm_zones is not yes, '
+                                'so it has no effect'.format(zone_name))
+                        continue
+                    if g.config['only_triggered_zm_zones'] == 'yes':
+                        g.logger.Debug(2, 'ignoring polygon: {} as only_triggered_zm_zones is true'.format(name))
+                        continue
+                    p = str2tuple(coords_str)
+                    g.polygons.append({
+                        'name': name,
+                        'value': p,
+                        'pattern': pattern,
+                        'ignore_pattern': ignore_pattern,
+                    })
+                    g.logger.Debug(2, 'adding polygon: {} [{}] pattern={} ignore_pattern={}'.format(
+                        name, coords_str, pattern, ignore_pattern))
         else:
             g.logger.Info(
                 'Ignoring monitor specific settings, as you did not provide a monitor id'


### PR DESCRIPTION
Fixes the ES 6 → ES 7 regression described in #48.

## The problem

Under ES 6, `objectconfig` named a zone and gave it a pattern; ZoneMinder owned the polygon. The two were joined by name after import (`utils.py:500-505` in 6.1.x).

ES 7 dropped that join:

- `process_config` only built a polygon when the config zone had `coords`. A zone declared with a `detection_pattern` and no `coords` was discarded silently — no warning, no error.
- `import_zm_zones` *appended* ZM's zones alongside the config ones instead of onto them. Since `pyzm.client._monitor_zones` never populates `Zone.pattern`, every imported polygon carried `pattern: None` → `.*`, which defeated the real per-zone pattern sitting next to it.

The result was that per-zone patterns and ZM-managed geometry became mutually exclusive: either hand-maintain a duplicate of every polygon in YAML (which goes stale the moment a zone is edited in the ZM web UI), or keep ZM's geometry and lose every pattern.

## The fix

`coords` is now optional.

- Every config zone records its patterns in `g.zone_patterns`, keyed by a normalised name, whether or not it has `coords`. Names are normalised on **both** sides (spaces → underscores, lowercased), so ZM's `My Driveway` joins to a config key of `my_driveway`.
- `import_zm_zones()` stamps those patterns onto the ZM zone of the same name instead of appending a duplicate.
- A config zone that *does* have `coords` still pins its own geometry, and the same-named ZM zone is no longer imported on top of it.

So `objectconfig.yml` expresses intent — which labels matter in which named zone — while ZoneMinder stays the source of truth for geometry, as in ES 6.

Precedence: config `coords` > ZM geometry; config pattern > ZM pattern.

## Zone entries that cannot take effect now say so

- a pattern with no `coords` and no `import_zm_zones` → error
- a pattern that matched no imported zone → error (quiet under `only_triggered_zm_zones`, where an untriggered zone is legitimately absent)
- `zm_detect` logs at Info when *no* zones are in effect at all, since pyzm's `filter_by_zone` short-circuits on an empty list and passes everything through. This is the frame-widening side effect noted at the end of #48; the join is what makes `import_zm_zones: "yes"` a usable answer for those monitors.

## Also

Monitor overrides now apply *before* the zone loop, so a per-monitor `import_zm_zones` or `only_triggered_zm_zones` is actually in effect while that monitor's zones are read. Previously it was not.

## Tests

10 new tests across `hook/tests/test_import_zm_zones.py` and `hook/tests/test_config_flow.py`. 8 fail on the pre-change tree and pass after; the other 2 are guards (an unconfigured ZM zone still gets `pattern: None`; the new error stays quiet under `only_triggered_zm_zones`). `conftest.StubLogger` now records what was logged so tests can assert on errors.

Gate green on all three tiers: perl 403 tests / 22 files, hook 182 passed (with the real pyzm checkout on `PYTHONPATH`), tools 107 passed.

Docs updated: a new "Letting ZoneMinder own the geometry" section in `hooks.rst` with the precedence rules, plus `config.rst`, `objectconfig.example.yml`, and the `testing.rst` test map.

## Note on interaction with pyzmNg#68

This restores the *join*. ZoneMinder/pyzmNg#68 (a zone's pattern rejection being overridden by any later overlapping zone) is independent and still open — with more zones now carrying real patterns instead of `.*`, that one becomes more visible, not less.

refs #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nDe6jjRuPnkAGEJo6vZUT
